### PR TITLE
new config option: InsecureSkipVerify - skips TLS certificate verification

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -18,6 +18,9 @@ elastic_login: ""
 elastic_password: ""
 elastic_maxretries: 4
 elastic_bulksize: 5000000
+# Если ES в контейнере и доступен по https, возможно игнорировать самоподписанную цепочку сертификатов.
+#skip_verify_certificates: true
+
 #
 # Правила формирования индекса Elasticsearch
 # Пример: "tech_journal_{event}_yyyyMMddhh", где event - CONN, EXCP, etc...


### PR DESCRIPTION
При запуске ES в контейнере amazon/opendistro-for-elasticsearch:1.4.0 он доступен по https.
Сертификаты самоподписанные и чтобы go-techlog1C подключился к Еластику надо заполнить самому tls.Config структуру с включенным InsecureSkipVerify. Который можно указать в конфиг файле.